### PR TITLE
add blacklist gui for appeng x nei ghost item compact

### DIFF
--- a/src/main/scala/net/bdew/neiaddons/appeng/AddonAppeng.java
+++ b/src/main/scala/net/bdew/neiaddons/appeng/AddonAppeng.java
@@ -35,6 +35,7 @@ public class AddonAppeng extends BaseAddon {
     public static AddonAppeng instance;
 
     public static final String setWorkbenchCommand = "SetAE2FakeSlot";
+    public static String[] blackListGuiName;
 
     public static Class<? extends GuiContainer> clsBaseGui;
     public static Class<? extends Container> clsBaseContainer;
@@ -60,6 +61,17 @@ public class AddonAppeng extends BaseAddon {
     @Override
     public void init(Side side) throws Exception {
         try {
+            blackListGuiName = NEIAddons.config
+                    .get(
+                            getName(),
+                            "Blacklist Gui Class Name",
+                            new String[] {
+                                "com.glodblock.github.client.gui.GuiFluidPatternTerminal",
+                                "com.glodblock.github.client.gui.GuiFluidPatternTerminalEx"
+                            },
+                            "These Gui won't have the NEI drag item handler from NEI addon.")
+                    .getStringList();
+
             clsBaseContainer = Utils.getAndCheckClass("appeng.container.AEBaseContainer", Container.class);
             clsSlotFake = Utils.getAndCheckClass("appeng.container.slot.SlotFake", Slot.class);
             mSlotFakeIsEnabled = clsSlotFake.getMethod("isEnabled");

--- a/src/main/scala/net/bdew/neiaddons/appeng/AppEngGuiHandler.java
+++ b/src/main/scala/net/bdew/neiaddons/appeng/AppEngGuiHandler.java
@@ -24,12 +24,10 @@ import net.minecraft.util.EnumChatFormatting;
 public class AppEngGuiHandler extends INEIGuiAdapter {
     @Override
     public boolean handleDragNDrop(GuiContainer gui, int mouseX, int mouseY, ItemStack draggedStack, int button) {
-        if (AddonAppeng.clsBaseGui.isInstance(gui)) {
+        if (AddonAppeng.clsBaseGui.isInstance(gui) && !checkBlacklist(gui)) {
             final Slot currentSlot = getSlotAtPosition(gui, mouseX, mouseY);
 
-            if (currentSlot != null
-                    && AddonAppeng.clsSlotFake.isInstance(currentSlot)
-                    && SlotHelper.isSlotEnabled(currentSlot)) {
+            if (AddonAppeng.clsSlotFake.isInstance(currentSlot) && SlotHelper.isSlotEnabled(currentSlot)) {
 
                 if (ClientHandler.enabledCommands.contains(AddonAppeng.setWorkbenchCommand)) {
                     final ItemStack stack = draggedStack.copy();
@@ -57,6 +55,16 @@ public class AppEngGuiHandler extends INEIGuiAdapter {
         }
 
         return super.handleDragNDrop(gui, mouseX, mouseY, draggedStack, button);
+    }
+
+    private boolean checkBlacklist(GuiContainer gui) {
+        String name = gui.getClass().getName();
+        for (String blacklist : AddonAppeng.blackListGuiName) {
+            if (blacklist.equals(name)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean isMouseOverSlot(GuiContainer gui, Slot slot, int mouseX, int mouseY) {

--- a/src/main/scala/net/bdew/neiaddons/appeng/SetFakeSlotCommandHandler.java
+++ b/src/main/scala/net/bdew/neiaddons/appeng/SetFakeSlotCommandHandler.java
@@ -22,9 +22,9 @@ public class SetFakeSlotCommandHandler implements SubPacketHandler {
         ItemStack stack = ItemStack.loadItemStackFromNBT(data.getCompoundTag("item"));
         int slotNum = data.getInteger("slot");
         Container cont = player.openContainer;
-        if ((cont != null) && AddonAppeng.clsBaseContainer.isInstance(cont)) {
+        if (AddonAppeng.clsBaseContainer.isInstance(cont)) {
             Slot slot = cont.getSlot(slotNum);
-            if ((slot != null) && AddonAppeng.clsSlotFake.isInstance(slot) && SlotHelper.isSlotEnabled(slot)) {
+            if (AddonAppeng.clsSlotFake.isInstance(slot) && SlotHelper.isSlotEnabled(slot)) {
                 ItemStack targetStack = slot.getStack();
                 if (null != targetStack && !data.getBoolean("replace") && stack.isItemEqual(targetStack)) {
                     stack.stackSize = slot.getStack().stackSize + stack.stackSize;


### PR DESCRIPTION
fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11601
make nei addon don't add default handler for every subclass of `AEBaseGui`, some of them have their own special handler and neiaddon's default hander may mess with them.
this blacklist is in config