### PR TITLE
Fix duplicate entries when viewing bee recipes by product

### DIFF
--- a/src/main/scala/net/bdew/neiaddons/forestry/bees/BeeHelper.java
+++ b/src/main/scala/net/bdew/neiaddons/forestry/bees/BeeHelper.java
@@ -8,10 +8,12 @@ package net.bdew.neiaddons.forestry.bees;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeSet;
 
 import net.bdew.neiaddons.Utils;
 import net.bdew.neiaddons.forestry.AddonForestry;
@@ -29,6 +31,7 @@ import forestry.api.apiculture.EnumBeeType;
 import forestry.api.apiculture.IAlleleBeeSpecies;
 import forestry.api.apiculture.IBeeRoot;
 import forestry.api.genetics.AlleleManager;
+import forestry.api.genetics.IAllele;
 import forestry.api.genetics.IAlleleSpecies;
 import forestry.core.config.Constants;
 
@@ -41,7 +44,7 @@ public class BeeHelper {
 
     private static void addProductToCache(Item item, IAlleleBeeSpecies species) {
         if (!productsCache.containsKey(item)) {
-            productsCache.put(item, new ArrayList<>());
+            productsCache.put(item, new TreeSet<>(Comparator.comparing(IAllele::getUID)));
         }
         productsCache.get(item).add(species);
     }


### PR DESCRIPTION
## Summary
For bees that produce multiple instances of the same item, but with different metadata, viewing the recipe for one of those outputs would show duplicate entries for the respective bee species. This leads to a lot of duplication in the NEI page, that mysteriously disappears when viewing all recipes, or the usage of said species.

For example, Iron Combs are produced by Iron, Steel and Manganese bees, yet this is what's displayed as their recipe:
<img width="345" height="783" alt="image" src="https://github.com/user-attachments/assets/1a73f4de-38cb-41d0-8d0b-a2b0f3fbcce5" />

This modifies the products cache for the Bee produce page to use a tree set instead that deduplicates the multiple species for the same item (but different metadata). I used a tree instead of a hash set, because the UID is what's ultimately used to reconstruct the producer and i'm not sure the allele instances are unique (hashcode seems to be the default, unreliable one).

This results in the correct display[^1] instead, again for the Iron Comb:
<img width="341" height="403" alt="image" src="https://github.com/user-attachments/assets/5093fb1f-1710-4ea3-aaa7-0a4fa70d3000" />

Note: In the setup method in the same class, there's a hash map called `seencombs` that only has elements added to it, but its values don't appear to be ever used. I assume this is an error because as it stands, it only consumes a bit of memory and processing for no use, and was probably meant as a filter before `API.addItemListEntry` with every comb is called, no? Whatever it is, I could amend the PR to add either that fix or a removal of it, whichever was desired originally.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge

[^1]: Note that I tested this based on version 1.17.0, and in my 2.8.4 instance, but the effect on the newest version and in fullpack should be the exact same.